### PR TITLE
Update server name sorting

### DIFF
--- a/apps/staging/lib/schemas/server.ex
+++ b/apps/staging/lib/schemas/server.ex
@@ -31,7 +31,10 @@ defmodule Staging.Server do
   end
 
   def order_by_name(query) do
-    from s in query, order_by: s.name
+    from s in query, order_by: [
+      fragment("regexp_matches(?, '^\D+')::text[]", s.name),
+      fragment("regexp_matches(?, '\d+$')::int[]", s.name)
+    ]
   end
 
   def archive_all(query) do

--- a/apps/staging/spec/staging_bot_spec.exs
+++ b/apps/staging/spec/staging_bot_spec.exs
@@ -62,6 +62,21 @@ defmodule Staging.BotSpec do
       end
     end
 
+    context "there are servers with numeric suffixes" do
+      before do
+        Factory.insert(:server, %{name: "qa-11", prod_data: false})
+        Factory.insert(:server, %{name: "qa-1", prod_data: false})
+        Factory.insert(:server, %{name: "beta-21", prod_data: false})
+        Factory.insert(:server, %{name: "beta-2", prod_data: false})
+      end
+
+      it "lists the servers alphabetically by name prefix then numerically by index suffix" do
+        Bot.handle_event(%{type: "message", text: "#{@bot_name} list", channel: @channel, user: @message_user.id}, @slack, [])
+        response = string_matching(~r/beta-2.+beta-21.+qa-1.+qa-11/iu)
+        expect(@slack_send).to have_received([response, @channel, @slack])
+      end
+    end
+
     context "some servers are archived" do
       before do
         Factory.insert(:server, %{name: "server-1", archived: false})


### PR DESCRIPTION
* First sort by variant prefix so `lh-beta-X` appears before `lh-qa-X`
* Then sort numerically by the variant index so `1` appears before `11`

## Before

```
example=# select * from servers order by name;

 id |    name
----+------------
 14 | lh-beta-1
 13 | lh-beta-11
  1 | lh-qa-1
  6 | lh-qa-10
  7 | lh-qa-11
  8 | lh-qa-12
 11 | lh-qa-13
  2 | lh-qa-2
 12 | lh-qa-24
  3 | lh-qa-3
  4 | lh-qa-4
  5 | lh-qa-5
  9 | lh-qa-6
 10 | lh-qa-7

(14 rows)
```

## After

```
example=# select * from servers order by regexp_matches(name, '\D+')::text[], regexp_matches(name, '\d+')::int[];

 id |    name
----+------------
 14 | lh-beta-1
 13 | lh-beta-11
  1 | lh-qa-1
  2 | lh-qa-2
  3 | lh-qa-3
  4 | lh-qa-4
  5 | lh-qa-5
  9 | lh-qa-6
 10 | lh-qa-7
  6 | lh-qa-10
  7 | lh-qa-11
  8 | lh-qa-12
 11 | lh-qa-13
 12 | lh-qa-24

(14 rows)
```