### PR TITLE
Fix server name sorting

### DIFF
--- a/apps/staging/lib/schemas/server.ex
+++ b/apps/staging/lib/schemas/server.ex
@@ -32,8 +32,8 @@ defmodule Staging.Server do
 
   def order_by_name(query) do
     from s in query, order_by: [
-      fragment("regexp_matches(?, '^\D+')::text[]", s.name),
-      fragment("regexp_matches(?, '\d+$')::int[]", s.name)
+      fragment("substring(? from '^\\D+')", s.name),
+      fragment("substring(? from '\\d+$')::int", s.name)
     ]
   end
 

--- a/apps/staging/spec/staging_bot_spec.exs
+++ b/apps/staging/spec/staging_bot_spec.exs
@@ -72,7 +72,7 @@ defmodule Staging.BotSpec do
 
       it "lists the servers alphabetically by name prefix then numerically by index suffix" do
         Bot.handle_event(%{type: "message", text: "#{@bot_name} list", channel: @channel, user: @message_user.id}, @slack, [])
-        response = string_matching(~r/beta-2.+beta-21.+qa-1.+qa-11/iu)
+        response = string_matching(~r/beta-2.+beta-21.+qa-1.+qa-11/ius)
         expect(@slack_send).to have_received([response, @channel, @slack])
       end
     end


### PR DESCRIPTION
- Backslash had to be escaped
- I think `substring` is better for sorting than `regexp_matches` since that returns a set instead of a string
- I needed to add the `s` regex modifier to handle the newlines in the server list message